### PR TITLE
Ensure thread-aware request building

### DIFF
--- a/frontend/src/pages/chat/Chat.tsx
+++ b/frontend/src/pages/chat/Chat.tsx
@@ -220,10 +220,15 @@ const Chat = () => {
     appStateContext?.dispatch({ type: 'UPDATE_CURRENT_CHAT', payload: conversation })
     setMessages(conversation.messages)
 
-    const request: ConversationRequest = {
-      messages: [...conversation.messages.filter(answer => answer.role !== ERROR)],
-      thread_id: conversation.thread_id
-    }
+    const request: ConversationRequest = conversation.thread_id
+      ? {
+          messages: [userMessage],
+          thread_id: conversation.thread_id
+        }
+      : {
+          messages: [...conversation.messages.filter(answer => answer.role !== ERROR)],
+          thread_id: conversation.thread_id
+        }
 
     let result = {} as ChatResponse
     try {


### PR DESCRIPTION
## Summary
- update Chat.tsx to submit only the last message when a thread id exists
- preserve the stored thread id during conversation requests

## Testing
- `npm test --prefix frontend` *(fails: jest not found)*
- `pytest -q` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68663664a078832590b9ae2618b1eba8