### PR TITLE
Ensure thread-aware request building

### DIFF
--- a/app.py
+++ b/app.py
@@ -443,6 +443,9 @@ async def send_chat_request(request_body, request_headers):
 async def send_assistant_request(request_body, request_headers):
     messages = request_body.get("messages", [])
     thread_id = request_body.get("thread_id")
+    logging.debug(
+        f"Assistant ID from settings: {app_settings.azure_openai.assistant_id}"
+    )
 
     if not messages:
         raise ValueError("No messages provided")
@@ -457,6 +460,7 @@ async def send_assistant_request(request_body, request_headers):
         if not thread_id:
             thread = await azure_openai_client.beta.threads.create()
             thread_id = thread.id
+            logging.debug(f"Created new thread: {thread_id}")
 
         await azure_openai_client.beta.threads.messages.create(
             thread_id=thread_id,
@@ -467,6 +471,9 @@ async def send_assistant_request(request_body, request_headers):
         run = await azure_openai_client.beta.threads.runs.create(
             thread_id=thread_id,
             assistant_id=app_settings.azure_openai.assistant_id,
+        )
+        logging.debug(
+            f"Created run {run.id} on thread {thread_id} with assistant ID {app_settings.azure_openai.assistant_id}"
         )
 
         while True:
@@ -643,6 +650,9 @@ async def stream_chat_request(request_body, request_headers):
 
 async def conversation_internal(request_body, request_headers):
     try:
+        logging.debug(
+            f"conversation_internal using assistant ID: {app_settings.azure_openai.assistant_id}"
+        )
         if (
             app_settings.azure_openai.stream
             and not app_settings.base_settings.use_promptflow

--- a/frontend/src/pages/chat/Chat.tsx
+++ b/frontend/src/pages/chat/Chat.tsx
@@ -220,10 +220,15 @@ const Chat = () => {
     appStateContext?.dispatch({ type: 'UPDATE_CURRENT_CHAT', payload: conversation })
     setMessages(conversation.messages)
 
-    const request: ConversationRequest = {
-      messages: [...conversation.messages.filter(answer => answer.role !== ERROR)],
-      thread_id: conversation.thread_id
-    }
+    const request: ConversationRequest = conversation.thread_id
+      ? {
+          messages: [userMessage],
+          thread_id: conversation.thread_id
+        }
+      : {
+          messages: [...conversation.messages.filter(answer => answer.role !== ERROR)],
+          thread_id: conversation.thread_id
+        }
 
     let result = {} as ChatResponse
     try {


### PR DESCRIPTION
## Summary
- update Chat.tsx to submit only the last message when a thread id exists
- preserve the stored thread id during conversation requests
- add debug logs to verify assistant id is detected on the backend

## Testing
- `npm test --prefix frontend` *(fails: jest not found)*
- `pytest -q` *(fails: missing dependencies)*


------
https://chatgpt.com/codex/tasks/task_e_68663664a078832590b9ae2618b1eba8