### PR TITLE
Ensure thread-aware request building

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,49 @@
+trigger:
+  branches:
+    include:
+      - main        # or your release branch
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+variables:
+  ACR_NAME: acrskfwwdev-duhyh2fverf0gcex         # <— your ACR login name, without .azurecr.io
+  IMAGE_NAME: webapp-azoa  # or whatever you prefer
+  WEBAPP_NAME: webapp-skfauto-ww-dev   # your Web App name
+  RESOURCE_GROUP: rg-ai-skf-ww-dev     # your resource-group
+  ACR_SERVICE_CONN: 'ACR-Service-Connection'  # DevOps service connection to your subscription
+  ARM_SERVICE_CONN: 'ARM-Service-Connection'
+stages:
+- stage: BuildAndPush
+  displayName: Build & Push Docker image
+  jobs:
+  - job: Docker
+    steps:
+    - checkout: self
+
+    # Build & push to ACR
+    - task: Docker@2
+      displayName: Build & Push to ACR
+      inputs:
+        command: buildAndPush
+        repository: $(IMAGE_NAME)
+        dockerfile: WebApp.Dockerfile
+        containerRegistry: $(ACR_SERVICE_CONN)   # set this up under Project Settings → Service connections
+        tags: |
+          latest
+          $(Build.BuildId)
+- stage: Deploy
+  displayName: Deploy to Web App
+  dependsOn: BuildAndPush
+  jobs:
+  - job: DeployWebApp
+    displayName: Deploy container to Web App
+    pool:
+      vmImage: 'ubuntu-latest'
+    steps:
+    - task: AzureWebAppContainer@1
+      inputs:
+        azureSubscription:  $(ARM_SERVICE_CONN) 
+        appName: $(WEBAPP_NAME)
+        resourceGroupName: $(RESOURCE_GROUP)
+        imageName: '$(ACR_NAME).azurecr.io/$(IMAGE_NAME):latest'

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -44,8 +44,8 @@ class _UiSettings(BaseSettings):
     title: str = "SkillForge"
     logo: Optional[str] = None
     chat_logo: Optional[str] = None
-    chat_title: str = "Start chatting"
-    chat_description: str = "This chatbot is configured to answer your questions"
+    chat_title: str = "Start learning"
+    chat_description: str = "This chatbot is configured to assist you in learning"
     favicon: str = "/favicon.ico"
     show_share_button: bool = True
     show_chat_history_button: bool = True

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -10,7 +10,8 @@ export async function conversationApi(options: ConversationRequest, abortSignal:
     },
     body: JSON.stringify({
       messages: options.messages,
-      thread_id: options.thread_id
+      thread_id: options.thread_id,
+      assistant_id: options.assistant_id
     }),
     signal: abortSignal
   })
@@ -122,11 +123,13 @@ export const historyGenerate = async (
   if (convId) {
     body = JSON.stringify({
       conversation_id: convId,
-      messages: options.messages
+      messages: options.messages,
+      assistant_id: options.assistant_id
     })
   } else {
     body = JSON.stringify({
-      messages: options.messages
+      messages: options.messages,
+      assistant_id: options.assistant_id
     })
   }
   const response = await fetch('/history/generate', {
@@ -326,6 +329,18 @@ export const frontendSettings = async (): Promise<Response | null> => {
       return null
     })
 
+  return response
+}
+
+export const listAssistants = async (): Promise<{id: string, name: string}[] | null> => {
+  const response = await fetch('/assistants', {
+    method: 'GET'
+  })
+    .then(res => res.json())
+    .catch(_err => {
+      console.error('There was an issue fetching assistants.')
+      return null
+    })
   return response
 }
 export const historyMessageFeedback = async (messageId: string, feedback: string): Promise<Response> => {

--- a/frontend/src/api/models.ts
+++ b/frontend/src/api/models.ts
@@ -89,6 +89,7 @@ export type ChatResponse = {
 export type ConversationRequest = {
   messages: ChatMessage[]
   thread_id?: string
+  assistant_id?: string | null
 }
 
 export type UserInfo = {

--- a/frontend/src/pages/chat/Chat.tsx
+++ b/frontend/src/pages/chat/Chat.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState, useEffect, useContext, useLayoutEffect } from 'react'
-import { CommandBarButton, IconButton, Dialog, DialogType, Stack } from '@fluentui/react'
+import { CommandBarButton, IconButton, Dialog, DialogType, Stack, Toggle, Dropdown, IDropdownOption } from '@fluentui/react'
 import { SquareRegular, ShieldLockRegular, ErrorCircleRegular } from '@fluentui/react-icons'
 
 import ReactMarkdown from 'react-markdown'
@@ -19,6 +19,7 @@ import {
   ChatMessage,
   ConversationRequest,
   conversationApi,
+  listAssistants,
   Citation,
   ToolMessageContent,
   AzureSqlServerExecResults,
@@ -65,6 +66,24 @@ const Chat = () => {
   const [errorMsg, setErrorMsg] = useState<ErrorMessage | null>()
   const [logo, setLogo] = useState('')
   const [answerId, setAnswerId] = useState<string>('')
+  const [useAssistant, setUseAssistant] = useState<boolean>(false)
+  const [assistants, setAssistants] = useState<IDropdownOption[]>([])
+  const [selectedAssistant, setSelectedAssistant] = useState<string>()
+  const [lastResponseTime, setLastResponseTime] = useState<string | null>(null)
+  const [retryMessage, setRetryMessage] = useState<ChatMessage | null>(null)
+
+  useEffect(() => {
+    if (useAssistant) {
+      listAssistants().then(res => {
+        if (res) {
+          setAssistants(res.map(a => ({ key: a.id, text: a.name || a.id })))
+          if (res.length > 0 && !selectedAssistant) {
+            setSelectedAssistant(res[0].id)
+          }
+        }
+      })
+    }
+  }, [useAssistant])
 
   const errorDialogContentProps = {
     type: DialogType.close,
@@ -182,6 +201,7 @@ const Chat = () => {
   const makeApiRequestWithoutCosmosDB = async (question: ChatMessage["content"], conversationId?: string) => {
     setIsLoading(true)
     setShowLoadingMessage(true)
+    const start = Date.now()
     const abortController = new AbortController()
     abortFuncs.current.unshift(abortController)
 
@@ -194,6 +214,7 @@ const Chat = () => {
       content: questionContent as string,
       date: new Date().toISOString()
     }
+    setRetryMessage(userMessage)
 
     let conversation: Conversation | null | undefined
     if (!conversationId) {
@@ -220,10 +241,17 @@ const Chat = () => {
     appStateContext?.dispatch({ type: 'UPDATE_CURRENT_CHAT', payload: conversation })
     setMessages(conversation.messages)
 
-    const request: ConversationRequest = {
-      messages: [...conversation.messages.filter(answer => answer.role !== ERROR)],
-      thread_id: conversation.thread_id
-    }
+    const request: ConversationRequest = conversation.thread_id
+      ? {
+          messages: [userMessage],
+          thread_id: conversation.thread_id,
+          assistant_id: useAssistant ? selectedAssistant : null
+        }
+      : {
+          messages: [...conversation.messages.filter(answer => answer.role !== ERROR)],
+          thread_id: conversation.thread_id,
+          assistant_id: useAssistant ? selectedAssistant : null
+        }
 
     let result = {} as ChatResponse
     try {
@@ -244,7 +272,7 @@ const Chat = () => {
               if (obj !== '' && obj !== '{}') {
                 runningText += obj
                 result = JSON.parse(runningText)
-                if (result.thread_id && !conversation.thread_id) {
+                if (result.thread_id && conversation && !conversation.thread_id) {
                   conversation.thread_id = result.thread_id
                 }
                 if (result.choices?.length > 0) {
@@ -274,6 +302,7 @@ const Chat = () => {
           })
         }
         conversation.messages.push(toolMessage, assistantMessage)
+        setLastResponseTime(((Date.now() - start)/1000).toFixed(1) + 's')
         appStateContext?.dispatch({ type: 'UPDATE_CURRENT_CHAT', payload: conversation })
         setMessages([...messages, toolMessage, assistantMessage])
       }
@@ -314,6 +343,7 @@ const Chat = () => {
   const makeApiRequestWithCosmosDB = async (question: ChatMessage["content"], conversationId?: string) => {
     setIsLoading(true)
     setShowLoadingMessage(true)
+    const start = Date.now()
     const abortController = new AbortController()
     abortFuncs.current.unshift(abortController)
     const questionContent = typeof question === 'string' ? question : [{ type: "text", text: question[0].text }, { type: "image_url", image_url: { url: question[1].image_url.url } }]
@@ -325,6 +355,7 @@ const Chat = () => {
       content: questionContent as string,
       date: new Date().toISOString()
     }
+    setRetryMessage(userMessage)
 
     let request: ConversationRequest
     let conversation
@@ -339,12 +370,14 @@ const Chat = () => {
       } else {
         conversation.messages.push(userMessage)
         request = {
-          messages: [...conversation.messages.filter(answer => answer.role !== ERROR)]
+          messages: [...conversation.messages.filter(answer => answer.role !== ERROR)],
+          assistant_id: useAssistant ? selectedAssistant : null
         }
       }
     } else {
       request = {
-        messages: [userMessage].filter(answer => answer.role !== ERROR)
+        messages: [userMessage].filter(answer => answer.role !== ERROR),
+        assistant_id: useAssistant ? selectedAssistant : null
       }
       setMessages(request.messages)
     }
@@ -464,6 +497,7 @@ const Chat = () => {
           return
         }
         appStateContext?.dispatch({ type: 'UPDATE_CURRENT_CHAT', payload: resultConversation })
+        setLastResponseTime(((Date.now() - start)/1000).toFixed(1) + 's')
         isEmpty(toolMessage)
           ? setMessages([...messages, assistantMessage])
           : setMessages([...messages, toolMessage, assistantMessage])
@@ -625,6 +659,8 @@ const Chat = () => {
     setIsCitationPanelOpen(false)
     setIsIntentsPanelOpen(false)
     setActiveCitation(undefined)
+    setLastResponseTime(null)
+    setRetryMessage(null)
     appStateContext?.dispatch({ type: 'UPDATE_CURRENT_CHAT', payload: null })
     setProcessMessages(messageStatus.Done)
   }
@@ -794,6 +830,13 @@ const Chat = () => {
       ) : (
         <Stack horizontal className={styles.chatRoot}>
           <div className={styles.chatContainer}>
+            <Stack horizontal tokens={{ childrenGap: 10 }} styles={{ root: { marginBottom: 10 } }}>
+              <Toggle label="Use Assistant" checked={useAssistant} onChange={(_, v) => setUseAssistant(!!v)} />
+              {useAssistant && (
+                <Dropdown options={assistants} selectedKey={selectedAssistant} onChange={(_, o) => setSelectedAssistant(o?.key as string)} placeholder="Assistant" styles={{ dropdown: { width: 150 } }} />
+              )}
+              {lastResponseTime && <span>Time: {lastResponseTime}</span>}
+            </Stack>
             {!messages || messages.length < 1 ? (
               <Stack className={styles.chatEmptyState}>
                 <img src={logo} className={styles.chatIcon} aria-hidden="true" />
@@ -871,6 +914,21 @@ const Chat = () => {
                   </span>
                 </Stack>
               )}
+              {!isLoading && messages.length > 0 && messages[messages.length - 1].role === ERROR && (
+                <CommandBarButton
+                  role="button"
+                  styles={{ root: { background: '#F0F0F0', marginRight: '8px' } }}
+                  iconProps={{ iconName: 'Refresh' }}
+                  onClick={() => {
+                    if (retryMessage) {
+                      appStateContext?.state.isCosmosDBAvailable?.cosmosDB
+                        ? makeApiRequestWithCosmosDB(retryMessage.content, appStateContext?.state.currentChat?.id)
+                        : makeApiRequestWithoutCosmosDB(retryMessage.content, appStateContext?.state.currentChat?.id)
+                    }
+                  }}
+                  aria-label="retry last request"
+                />
+              )}
               <Stack>
                 {appStateContext?.state.isCosmosDBAvailable?.status !== CosmosDBStatus.NotConfigured && (
                   <CommandBarButton
@@ -929,6 +987,14 @@ const Chat = () => {
                   }
                   disabled={disabledButton()}
                   aria-label="clear chat button"
+                />
+                <CommandBarButton
+                  role="button"
+                  styles={{ root: { background: '#F0F0F0', marginLeft: '8px' } }}
+                  iconProps={{ iconName: 'Refresh' }}
+                  onClick={newChat}
+                  disabled={disabledButton()}
+                  aria-label="reset conversation"
                 />
                 <Dialog
                   hidden={hideErrorDialog}


### PR DESCRIPTION
## Summary
- update `Chat.tsx` to set `assistant_id` to null when assistant toggle is off and continue threads by sending only the latest user message
- allow `assistant_id` to be `string | null` in `ConversationRequest`
- keep debug logs showing assistant detection
- merge latest `main` branch

## Testing
- `npm test --prefix frontend` *(fails: jest not found)*
- `pytest -q` *(fails: missing modules)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68663664a078832590b9ae2618b1eba8