### PR TITLE
Assistant-first message when selected

### DIFF
--- a/frontend/src/pages/chat/Chat.tsx
+++ b/frontend/src/pages/chat/Chat.tsx
@@ -85,6 +85,14 @@ const Chat = () => {
     }
   }, [useAssistant])
 
+  useEffect(() => {
+    if (useAssistant && messages.length === 0) {
+      appStateContext?.state.isCosmosDBAvailable?.cosmosDB
+        ? makeApiRequestWithCosmosDB('')
+        : makeApiRequestWithoutCosmosDB('')
+    }
+  }, [useAssistant])
+
   const errorDialogContentProps = {
     type: DialogType.close,
     title: errorMsg?.title,
@@ -664,6 +672,11 @@ const Chat = () => {
     setRetryMessage(null)
     appStateContext?.dispatch({ type: 'UPDATE_CURRENT_CHAT', payload: null })
     setProcessMessages(messageStatus.Done)
+    if (useAssistant) {
+      appStateContext?.state.isCosmosDBAvailable?.cosmosDB
+        ? makeApiRequestWithCosmosDB('')
+        : makeApiRequestWithoutCosmosDB('')
+    }
   }
 
   const stopGenerating = () => {


### PR DESCRIPTION
## Summary
- allow the assistant to start the chat when assistant mode is enabled
- fetch assistant list on toggle and request initial message

## Testing
- `npm test` *(fails: jest not found)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6866b94922e08325b35ebb39f5a6ec96