### PR TITLE
Assistant-first message when selected

### DIFF
--- a/frontend/src/pages/chat/Chat.tsx
+++ b/frontend/src/pages/chat/Chat.tsx
@@ -85,6 +85,14 @@ const Chat = () => {
     }
   }, [useAssistant])
 
+  useEffect(() => {
+    if (useAssistant && selectedAssistant && messages.length === 0) {
+      appStateContext?.state.isCosmosDBAvailable?.cosmosDB
+        ? makeApiRequestWithCosmosDB('')
+        : makeApiRequestWithoutCosmosDB('')
+    }
+  }, [useAssistant, selectedAssistant, messages])
+
   const errorDialogContentProps = {
     type: DialogType.close,
     title: errorMsg?.title,
@@ -664,6 +672,11 @@ const Chat = () => {
     setRetryMessage(null)
     appStateContext?.dispatch({ type: 'UPDATE_CURRENT_CHAT', payload: null })
     setProcessMessages(messageStatus.Done)
+    if (useAssistant && selectedAssistant) {
+      appStateContext?.state.isCosmosDBAvailable?.cosmosDB
+        ? makeApiRequestWithCosmosDB('')
+        : makeApiRequestWithoutCosmosDB('')
+    }
   }
 
   const stopGenerating = () => {


### PR DESCRIPTION
## Summary
- allow the assistant to start the chat when assistant mode is enabled
- fetch assistant list on toggle and request initial message using selected assistant

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest -q` *(fails: ModuleNotFoundError for azure)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6866b94922e08325b35ebb39f5a6ec96