### PR TITLE
Clarify streaming usage for assistants

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Note: RBAC assignments can take a few minutes before becoming effective.
     |AZURE_OPENAI_MAX_TOKENS|No|1000|The maximum number of tokens allowed for the generated answer.|
     |AZURE_OPENAI_STOP_SEQUENCE|No||Up to 4 sequences where the API will stop generating further tokens. Represent these as a string joined with "|", e.g. `"stop1|stop2|stop3"`|
     |AZURE_OPENAI_SYSTEM_MESSAGE|No|You are an AI assistant that helps people find information.|A brief description of the role and tone the model should use|
-    |AZURE_OPENAI_STREAM|No|True|Whether or not to use streaming for the response. Note: Setting this to true prevents the use of prompt flow.|
+|AZURE_OPENAI_STREAM|No|True|Whether or not to use streaming for the response. Note: Setting this to true prevents the use of prompt flow. This must be true when using the Assistants API, which streams tokens back incrementally.|
     |AZURE_OPENAI_ASSISTANT_ID|No||ID of the assistant to use when calling the Assistants API. If set, chat history is maintained server side using threads.|
     |AZURE_OPENAI_EMBEDDING_NAME|Only if using vector search using an Azure OpenAI embedding model||The name of your embedding model deployment if using vector search.
     |MS_DEFENDER_ENABLED|Yes|True|Whether or not the Microsoft Defender for Cloud's threat protection for AI workloads plan is enabled on your subscription or not , for more details [Microsoft Defender for Cloud documentation](https://learn.microsoft.com/azure/defender-for-cloud/gain-end-user-context-ai).|

--- a/app.py
+++ b/app.py
@@ -525,6 +525,42 @@ async def send_assistant_request(request_body, request_headers):
         raise e
 
 
+async def stream_assistant_request(request_body, request_headers):
+    messages = request_body.get("messages", [])
+    thread_id = request_body.get("thread_id")
+    assistant_id = request_body.get("assistant_id") or app_settings.azure_openai.assistant_id
+
+    user_message = messages[-1] if messages else None
+    if user_message and user_message.get("role") != "user":
+        raise ValueError("Last message must be from user")
+
+    azure_openai_client = await init_openai_client()
+
+    if not thread_id:
+        thread = await azure_openai_client.beta.threads.create()
+        thread_id = thread.id
+        logging.debug(f"Created new thread: {thread_id}")
+
+    if user_message:
+        await azure_openai_client.beta.threads.messages.create(
+            thread_id=thread_id,
+            role="user",
+            content=user_message["content"],
+        )
+
+    stream = await azure_openai_client.beta.threads.runs.create(
+        thread_id=thread_id,
+        assistant_id=assistant_id,
+        stream=True,
+    )
+
+    async def generate():
+        async for event in stream:
+            yield event
+
+    return generate()
+
+
 async def complete_chat_request(request_body, request_headers):
     if app_settings.base_settings.use_promptflow:
         response = await promptflow_request(request_body)
@@ -656,12 +692,12 @@ async def conversation_internal(request_body, request_headers):
         logging.debug(
             f"conversation_internal using assistant ID: {request_body.get('assistant_id') or app_settings.azure_openai.assistant_id}"
         )
-        if (
-            app_settings.azure_openai.stream
-            and not app_settings.base_settings.use_promptflow
-            and not request_body.get("assistant_id")
-        ):
-            result = await stream_chat_request(request_body, request_headers)
+        if app_settings.azure_openai.stream and not app_settings.base_settings.use_promptflow:
+            if request_body.get("assistant_id"):
+                result = await stream_assistant_request(request_body, request_headers)
+            else:
+                result = await stream_chat_request(request_body, request_headers)
+
             response = await make_response(format_as_ndjson(result))
             response.timeout = None
             response.mimetype = "application/json-lines"


### PR DESCRIPTION
## Summary
- note that streaming must be enabled and tokens stream incrementally when using the Assistants API
- support streaming Assistants API responses

## Testing
- `pytest -k "not integration" -q` *(fails: ModuleNotFoundError: No module named 'azure')*

------
https://chatgpt.com/codex/tasks/task_e_6866c726492083259b75c285bde68d3e