### PR TITLE
Fix streaming serialization of assistant events

### DIFF
--- a/backend/utils.py
+++ b/backend/utils.py
@@ -19,6 +19,13 @@ class JSONEncoder(json.JSONEncoder):
     def default(self, o):
         if dataclasses.is_dataclass(o):
             return dataclasses.asdict(o)
+        # Support pydantic models used by the OpenAI SDK
+        if hasattr(o, "model_dump") and callable(o.model_dump):
+            return o.model_dump()
+        if hasattr(o, "dict") and callable(o.dict):
+            return o.dict()
+        if hasattr(o, "__dict__"):
+            return o.__dict__
         return super().default(o)
 
 


### PR DESCRIPTION
## Summary
- ensure OpenAI assistant stream events can be serialized by extending JSONEncoder

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'azure')*

------
https://chatgpt.com/codex/tasks/task_e_68678fb098d08325a18b3365130f46e6