### PR TITLE
Add assistant preload and response time display

### DIFF
--- a/frontend/src/api/models.ts
+++ b/frontend/src/api/models.ts
@@ -45,6 +45,7 @@ export type ChatMessage = {
   date: string
   feedback?: Feedback
   context?: string
+  response_time?: string
 }
 
 export type ExecResults = {

--- a/frontend/src/pages/chat/Chat.module.css
+++ b/frontend/src/pages/chat/Chat.module.css
@@ -370,6 +370,12 @@ a {
   border-radius: 4px;
 }
 
+.responseTime {
+  font-size: 12px;
+  color: #555;
+  margin-top: 4px;
+}
+
 @media (max-width: 480px) {
   .chatInput {
     width: 90%;


### PR DESCRIPTION
## Summary
- preload assistants list on chat page load and cache in sessionStorage
- record response time for each assistant message
- display response time below assistant answers

## Testing
- `npm test --prefix frontend` *(fails: jest not found)*
- `pytest -k "not integration"` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6867d4351e648325aa27a71ca1169ba1