### PR TITLE
Move response time display

### DIFF
--- a/frontend/src/api/models.ts
+++ b/frontend/src/api/models.ts
@@ -6,6 +6,7 @@ export type AskResponse = {
   message_id?: string
   feedback?: Feedback
   exec_results?: ExecResults[]
+  response_time?: string
 }
 
 export type Citation = {

--- a/frontend/src/components/Answer/Answer.tsx
+++ b/frontend/src/components/Answer/Answer.tsx
@@ -323,9 +323,11 @@ export const Answer = ({ answer, onCitationClicked, onExectResultClicked }: Prop
               </Stack>
             </Stack.Item>
           )}
-          <Stack.Item className={styles.answerDisclaimerContainer}>
-            <span className={styles.answerDisclaimer}>AI-generated content may be incorrect</span>
-          </Stack.Item>
+          {answer.response_time && (
+            <Stack.Item className={styles.answerDisclaimerContainer}>
+              <span className={styles.answerDisclaimer}>Time: {answer.response_time}</span>
+            </Stack.Item>
+          )}
           {!!answer.exec_results?.length && (
             <Stack.Item onKeyDown={e => (e.key === 'Enter' || e.key === ' ' ? toggleIsRefAccordionOpen() : null)}>
               <Stack style={{ width: '100%' }}>

--- a/frontend/src/pages/chat/Chat.tsx
+++ b/frontend/src/pages/chat/Chat.tsx
@@ -882,11 +882,6 @@ const Chat = () => {
                           onCitationClicked={c => onShowCitation(c)}
                           onExectResultClicked={() => onShowExecResult(answerId)}
                         />}
-                        {answer.response_time && (
-                          <div className={styles.responseTime}>
-                            Time: {answer.response_time}
-                          </div>
-                        )}
                       </div>
                     ) : answer.role === ERROR ? (
                       <div className={styles.chatMessageError}>


### PR DESCRIPTION
## Summary
- show response time in Answer component instead of disclaimer
- drop inline response time div in Chat page
- update AskResponse type with `response_time`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'azure', ModuleNotFoundError: No module named 'backend')*
- `npm test --prefix frontend` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867fd56af608325be0f944ed72b7018