### PR TITLE
Fix response time display

### DIFF
--- a/frontend/src/pages/chat/Chat.tsx
+++ b/frontend/src/pages/chat/Chat.tsx
@@ -875,9 +875,10 @@ const Chat = () => {
                             answer: answer.content,
                             citations: parseCitationFromMessage(messages[index - 1]),
                             generated_chart: parsePlotFromMessage(messages[index - 1]),
-                            message_id: answer.id,
-                            feedback: answer.feedback,
-                            exec_results: execResults
+                          message_id: answer.id,
+                          feedback: answer.feedback,
+                          exec_results: execResults,
+                          response_time: answer.response_time
                           }}
                           onCitationClicked={c => onShowCitation(c)}
                           onExectResultClicked={() => onShowExecResult(answerId)}


### PR DESCRIPTION
## Summary
- ensure assistant message passes response_time to `Answer`

## Testing
- `pytest -k "not integration"` *(fails: ModuleNotFoundError: No module named 'azure')*

------
https://chatgpt.com/codex/tasks/task_e_686810190c808325b67d1b7fe6c25023