### PR TITLE
Add auto-scroll on streaming

### DIFF
--- a/frontend/src/pages/chat/Chat.tsx
+++ b/frontend/src/pages/chat/Chat.tsx
@@ -776,6 +776,12 @@ const Chat = () => {
     chatMessageStreamEnd.current?.scrollIntoView({ behavior: 'smooth' })
   }, [showLoadingMessage, processMessages])
 
+  useEffect(() => {
+    if (processMessages === messageStatus.Processing) {
+      chatMessageStreamEnd.current?.scrollIntoView({ behavior: 'smooth' })
+    }
+  }, [messages])
+
   const onShowCitation = (citation: Citation) => {
     setActiveCitation(citation)
     setIsCitationPanelOpen(true)


### PR DESCRIPTION
## Summary
- ensure chat window scrolls automatically while streaming messages

## Testing
- `npm test` *(fails: jest not found)*
- `pytest -q` *(fails: ModuleNotFoundError for azure)*

------
https://chatgpt.com/codex/tasks/task_e_68685f7898188325a17de5359d97b1bc